### PR TITLE
Auto-generate release notes from commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -38,8 +40,34 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Generate release notes
+        id: notes
+        shell: bash
+        run: |
+          # Find the previous tag
+          PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | sed -n '2p')
+          if [ -z "$PREV_TAG" ]; then
+            # First release — use all commits
+            NOTES=$(git log --pretty=format:"- %s" HEAD)
+          else
+            NOTES=$(git log --pretty=format:"- %s" "${PREV_TAG}..HEAD")
+          fi
+          # Write to file to handle multiline
+          echo "$NOTES" > /tmp/release-notes.md
+
       - name: Install dependencies
         run: pnpm install
+
+      - name: Read release notes
+        id: read_notes
+        shell: bash
+        run: |
+          BODY=$(cat /tmp/release-notes.md)
+          # Use GH actions delimiter for multiline output
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "body<<$EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0
@@ -49,7 +77,7 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "PrintQueue ${{ github.ref_name }}"
-          releaseBody: "See the assets below to download and install this version."
+          releaseBody: ${{ steps.read_notes.outputs.body }}
           releaseDraft: false
           prerelease: false
           args: --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Replace the static release body with auto-generated release notes from git commit history.

## Changes

- **`.github/workflows/release.yml`**:
  - Added `fetch-depth: 0` to checkout so full git history is available
  - New "Generate release notes" step finds the previous `v*` tag and collects commit messages since then
  - Falls back to all commits if this is the first release
  - Release body now lists each commit as a bullet point

## Example output

For a release tagged `v0.2.0` with `v0.1.0` as the previous tag:

```
- Add auto-updater with GitHub Releases
- Fix missing HashMap import in printing.rs
- Replace app icon with white printer on dark background
```

## Test plan

- [x] Tag a new release and verify the release body contains commit messages
- [x] First release (no prior tag) should list all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)