### PR TITLE
Style scrollbars to match app theme

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3262,7 +3262,7 @@ dependencies = [
 
 [[package]]
 name = "print-queue"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "flate2",

--- a/src/App.css
+++ b/src/App.css
@@ -117,6 +117,9 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+
+    scrollbar-width: auto;
+    scrollbar-color: var(--border) transparent;
   }
 
   body {


### PR DESCRIPTION
## Summary
- Adds `scrollbar-color` using the theme's border color with transparent track
- Standard width (`auto`) so scrollbars feel native but match the dark theme

## Test plan
- [x] Scrollbar on Settings page matches the dark theme instead of default Windows chrome
- [x] Works in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)