### PR TITLE
Rename print-queue → hello-print / Hello Print

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: "PrintQueue ${{ github.ref_name }}"
+          releaseName: "Hello Print ${{ github.ref_name }}"
           releaseBody: ${{ steps.read_notes.outputs.body }}
           releaseDraft: false
           prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ tmp/
 .keys/
 
 # Compiled macOS helper (built during cargo build)
-src-tauri/macos-helper/printqueue-macos-helper
+src-tauri/macos-helper/hello-print-macos-helper

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PrintQueue is a Tauri v2 desktop application that automates photo printing workflows. It watches a folder for .zip/image files, extracts images from zips, parses filenames for size keywords (e.g. `4x6`, `A4`), routes them to matching printer presets, and submits print jobs automatically. See `PRD.md` for full product requirements.
+Hello Print is a Tauri v2 desktop application that automates photo printing workflows. It watches a folder for .zip/image files, extracts images from zips, parses filenames for size keywords (e.g. `4x6`, `A4`), routes them to matching printer presets, and submits print jobs automatically. See `PRD.md` for full product requirements.
 
 ## Tech Stack
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,8 +1,8 @@
-# PrintQueue — Product Requirements Document
+# Hello Print — Product Requirements Document
 
 ## Overview
 
-PrintQueue is a cross-platform desktop application built with Tauri that automates photo printing workflows for makers and small business owners. Users configure a watch folder, select their printer and settings, and the app automatically detects new zip files, extracts images, and sends them to the printer with the correct preset configuration — eliminating the manual process of unzipping, opening print software, configuring settings, and drag-and-dropping files for every batch.
+Hello Print is a cross-platform desktop application built with Tauri that automates photo printing workflows for makers and small business owners. Users configure a watch folder, select their printer and settings, and the app automatically detects new zip files, extracts images, and sends them to the printer with the correct preset configuration — eliminating the manual process of unzipping, opening print software, configuring settings, and drag-and-dropping files for every batch.
 
 ## Problem Statement
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PrintQueue
+# Hello Print
 
 A cross-platform desktop application built with Tauri that automates photo printing workflows for makers and small business owners. Users configure a watch folder, select their printer and settings, and the app automatically detects new zip files, extracts images, and sends them to the printer with the correct preset configuration.
 
@@ -82,9 +82,9 @@ plus the auto-updater manifest.
 
 ### What gets published
 
-- `print-queue_X.Y.Z_x64-setup.exe` — Windows installer (NSIS)
-- `print-queue_X.Y.Z_aarch64.dmg` — macOS Apple Silicon (M-series)
-- `print-queue_X.Y.Z_x64.dmg` — macOS Intel
+- `Hello Print_X.Y.Z_x64-setup.exe` — Windows installer (NSIS)
+- `Hello Print_X.Y.Z_aarch64.dmg` — macOS Apple Silicon (M-series)
+- `Hello Print_X.Y.Z_x64.dmg` — macOS Intel
 - `latest.json` + `.sig` files — consumed by the in-app auto-updater
 
 ### Updater signing
@@ -95,7 +95,7 @@ is baked into `tauri.conf.json`.
 - **CI:** the private key is provided via the `TAURI_SIGNING_PRIVATE_KEY`
   repository secret.
 - **Local signed builds:** `mise.toml` points `TAURI_SIGNING_PRIVATE_KEY` at
-  `.keys/print-queue.key` (gitignored). Run `mise trust` once, then
+  `.keys/hello-print.key` (gitignored). Run `mise trust` once, then
   `pnpm tauri build` produces signed artifacts. Use `pnpm tauri build --no-bundle`
   for an unsigned compile-only check.
 
@@ -103,4 +103,4 @@ is baked into `tauri.conf.json`.
 
 Builds are **not** code-signed/notarized (no Apple Developer account). On first
 launch macOS users must clear the quarantine flag:
-`xattr -cr /Applications/print-queue.app`. Tracked in issue #13.
+`xattr -cr "/Applications/Hello Print.app"`. Tracked in issue #13.

--- a/current-state.md
+++ b/current-state.md
@@ -1,4 +1,4 @@
-# PrintQueue — Current State (2026-02-23)
+# Hello Print — Current State (2026-02-23)
 
 ## Overview
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PrintQueue</title>
+    <title>Hello Print</title>
   </head>
 
   <body>

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,6 @@ run = "sudo apt-get update && sudo apt-get install -y libcups2-dev"
 [env]
 # Tauri updater signing key (path read by `tauri build` to sign updater artifacts).
 # The key file itself is gitignored under .keys/; only this path is committed.
-TAURI_SIGNING_PRIVATE_KEY = "{{config_root}}/.keys/print-queue.key"
+TAURI_SIGNING_PRIVATE_KEY = "{{config_root}}/.keys/hello-print.key"
 # Key was generated with an empty password; set it explicitly to skip the prompt.
 TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "print-queue",
+  "name": "hello-print",
   "version": "0.1.12",
   "private": true,
   "type": "module",

--- a/scripts/bump.mjs
+++ b/scripts/bump.mjs
@@ -59,10 +59,10 @@ let cargo = readFileSync(cargoPath, "utf-8");
 cargo = cargo.replace(/^version\s*=\s*"[^"]*"/m, `version = "${next}"`);
 writeFileSync(cargoPath, cargo);
 
-// Update Cargo.lock (the print-queue package's own version entry)
+// Update Cargo.lock (the hello-print package's own version entry)
 const lockPath = resolve(root, "src-tauri", "Cargo.lock");
 let lock = readFileSync(lockPath, "utf-8");
-lock = lock.replace(/(name = "print-queue"\nversion = )"[^"]*"/, `$1"${next}"`);
+lock = lock.replace(/(name = "hello-print"\nversion = )"[^"]*"/, `$1"${next}"`);
 writeFileSync(lockPath, lock);
 
 console.log(`${current} → ${next}`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1788,6 +1788,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hello-print"
+version = "0.1.12"
+dependencies = [
+ "chrono",
+ "flate2",
+ "hex",
+ "image",
+ "lopdf",
+ "notify",
+ "notify-debouncer-full",
+ "printers",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-notification",
+ "tauri-plugin-opener",
+ "tauri-plugin-updater",
+ "uuid",
+ "zip 8.6.0",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,31 +3553,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "print-queue"
-version = "0.1.12"
-dependencies = [
- "chrono",
- "flate2",
- "hex",
- "image",
- "lopdf",
- "notify",
- "notify-debouncer-full",
- "printers",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
- "tauri-plugin-notification",
- "tauri-plugin-opener",
- "tauri-plugin-updater",
- "uuid",
- "zip 8.6.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "print-queue"
+name = "hello-print"
 version = "0.1.12"
-description = "A Tauri App"
-authors = ["you"]
+description = "Automated photo printing workflows for makers"
+authors = ["Jake Klassen <jklassendev@gmail.com>"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ edition = "2021"
 # The `_lib` suffix may seem redundant but it is necessary
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
-name = "print_queue_lib"
+name = "hello_print_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -9,7 +9,7 @@ fn main() {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let out_dir = std::env::var("OUT_DIR").unwrap();
         let source =
-            std::path::Path::new(&manifest_dir).join("macos-helper/PrintQueueMacHelper.swift");
+            std::path::Path::new(&manifest_dir).join("macos-helper/HelloPrintMacHelper.swift");
 
         if source.exists() {
             // Determine the swiftc -target triple from the Rust target architecture.
@@ -23,7 +23,7 @@ fn main() {
             };
             let swift_target = format!("{}-apple-macosx11.0", swift_arch);
 
-            let build_binary = std::path::Path::new(&out_dir).join("printqueue-macos-helper");
+            let build_binary = std::path::Path::new(&out_dir).join("hello-print-macos-helper");
 
             let output = Command::new("xcrun")
                 .args([
@@ -54,7 +54,7 @@ fn main() {
             // Only copy when content differs to avoid triggering Tauri's file
             // watcher, which would cause an infinite rebuild loop during `tauri dev`.
             let staging_dir = std::path::Path::new(&manifest_dir).join("macos-helper");
-            let staging_binary = staging_dir.join("printqueue-macos-helper");
+            let staging_binary = staging_dir.join("hello-print-macos-helper");
 
             let needs_copy = if staging_binary.exists() {
                 let build_bytes =

--- a/src-tauri/macos-helper/HelloPrintMacHelper.swift
+++ b/src-tauri/macos-helper/HelloPrintMacHelper.swift
@@ -117,7 +117,7 @@ func logPrintSettings(_ label: String, printInfo: NSPrintInfo) {
         .map { String(describing: $0) }
         .sorted()
         .joined(separator: ", ")
-    fputs("[PrintQueue][macOS] \(label) printSettings keys: \(pairs)\n", stderr)
+    fputs("[HelloPrint][macOS] \(label) printSettings keys: \(pairs)\n", stderr)
 }
 
 func applyPMState(
@@ -231,7 +231,7 @@ func configure(arguments: [String], printerHint: String?) throws {
     }
 
     fputs(
-        "[PrintQueue][macOS] captured blob lengths: printInfo=\(printInfoBase64.count), pageFormat=\(pageFormatBase64.count), printSettings=\(printSettingsBase64.count)\n",
+        "[HelloPrint][macOS] captured blob lengths: printInfo=\(printInfoBase64.count), pageFormat=\(pageFormatBase64.count), printSettings=\(printSettingsBase64.count)\n",
         stderr
     )
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -119,7 +119,7 @@ public static class PrinterDialog {{
     );
 
     let script_path = std::env::temp_dir().join(format!(
-        "printqueue_dialog_{}.ps1",
+        "helloprint_dialog_{}.ps1",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()

--- a/src-tauri/src/macos_printing.rs
+++ b/src-tauri/src/macos_printing.rs
@@ -17,7 +17,7 @@ use crate::printing::PrinterInfo;
 use lopdf::dictionary;
 
 #[cfg(target_os = "macos")]
-const HELPER_BINARY_NAME: &str = "macos-helper/printqueue-macos-helper";
+const HELPER_BINARY_NAME: &str = "macos-helper/hello-print-macos-helper";
 #[cfg(target_os = "macos")]
 const HELPER_RESOURCE_FALLBACK_NAME: &str = "macos-helper";
 
@@ -64,7 +64,7 @@ fn resolve_helper(app: &AppHandle) -> Result<PathBuf, String> {
     }
 
     // Dev fallback: compile from source
-    let source = Path::new(env!("CARGO_MANIFEST_DIR")).join("macos-helper/PrintQueueMacHelper.swift");
+    let source = Path::new(env!("CARGO_MANIFEST_DIR")).join("macos-helper/HelloPrintMacHelper.swift");
     let data_dir = app
         .path()
         .app_data_dir()
@@ -72,7 +72,7 @@ fn resolve_helper(app: &AppHandle) -> Result<PathBuf, String> {
     let helper_dir = data_dir.join("macos-helper");
     fs::create_dir_all(&helper_dir)
         .map_err(|e| format!("Failed to create helper dir: {}", e))?;
-    let binary = helper_dir.join("printqueue-macos-helper");
+    let binary = helper_dir.join("hello-print-macos-helper");
 
     let should_build = match (fs::metadata(&source), fs::metadata(&binary)) {
         (Ok(source_meta), Ok(binary_meta)) => {
@@ -119,7 +119,7 @@ fn run_helper(app: &AppHandle, args: &[String]) -> Result<String, String> {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !stderr.trim().is_empty() {
-        eprintln!("[PrintQueue][macOS] helper stderr: {}", stderr.trim());
+        eprintln!("[HelloPrint][macOS] helper stderr: {}", stderr.trim());
     }
 
     if !output.status.success() {
@@ -387,7 +387,7 @@ fn wrap_image_in_pdf(image_path: &Path, preset: &Preset) -> Result<PathBuf, Stri
     doc.trailer.set("Root", catalog_id);
 
     let pdf_path = std::env::temp_dir().join(format!(
-        "printqueue-native-{}.pdf",
+        "helloprint-native-{}.pdf",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    print_queue_lib::run()
+    hello_print_lib::run()
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -6,7 +6,7 @@ use tauri::{
 };
 
 pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
-    let open_item = MenuItem::with_id(app, "open", "Open PrintQueue", true, None::<&str>)?;
+    let open_item = MenuItem::with_id(app, "open", "Open Hello Print", true, None::<&str>)?;
     let pause_item = MenuItem::with_id(app, "pause", "Pause Watching", true, None::<&str>)?;
     let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
@@ -18,7 +18,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
 
     let _tray = TrayIconBuilder::new()
         .icon(icon)
-        .tooltip("PrintQueue")
+        .tooltip("Hello Print")
         .menu(&menu)
         .on_menu_event(move |app, event| match event.id.as_ref() {
             "open" => {

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -445,7 +445,7 @@ fn submit_print_windows(file_path: &Path, printer_id: &str, preset: &Preset) -> 
 
     // Write script to a unique temp file (avoid races with concurrent jobs)
     let script_path = std::env::temp_dir().join(format!(
-        "printqueue_{}.ps1",
+        "helloprint_{}.ps1",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -455,7 +455,7 @@ fn submit_print_windows(file_path: &Path, printer_id: &str, preset: &Preset) -> 
         .map_err(|e| format!("Failed to write script: {}", e))?;
 
     eprintln!(
-        "[PrintQueue] Submitting print job: printer={}, file={}",
+        "[HelloPrint] Submitting print job: printer={}, file={}",
         printer_id,
         file_path.display()
     );
@@ -479,11 +479,11 @@ fn submit_print_windows(file_path: &Path, printer_id: &str, preset: &Preset) -> 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    eprintln!("[PrintQueue] PS stdout: {}", stdout.trim());
+    eprintln!("[HelloPrint] PS stdout: {}", stdout.trim());
     if !stderr.is_empty() {
-        eprintln!("[PrintQueue] PS stderr: {}", stderr.trim());
+        eprintln!("[HelloPrint] PS stderr: {}", stderr.trim());
     }
-    eprintln!("[PrintQueue] PS exit code: {:?}", output.status.code());
+    eprintln!("[HelloPrint] PS exit code: {:?}", output.status.code());
 
     if stdout.contains("SUCCESS") {
         return Ok(());
@@ -737,7 +737,7 @@ fn submit_print_unix(file_path: &Path, printer_id: &str, preset: &Preset) -> Res
             // Skip Resolution when vendor quality is set — it overrides quality
             if key == "Resolution" && has_vendor_quality {
                 eprintln!(
-                    "[PrintQueue] Skipping Resolution={} (EPIJ_Qual controls resolution)",
+                    "[HelloPrint] Skipping Resolution={} (EPIJ_Qual controls resolution)",
                     value
                 );
                 continue;
@@ -757,7 +757,7 @@ fn submit_print_unix(file_path: &Path, printer_id: &str, preset: &Preset) -> Res
         // when submitting DeviceRGB content (it assumes sRGB input).
 
         eprintln!(
-            "[PrintQueue] lpoptions -p {} {}",
+            "[HelloPrint] lpoptions -p {} {}",
             printer_id,
             opt_log
                 .iter()
@@ -771,7 +771,7 @@ fn submit_print_unix(file_path: &Path, printer_id: &str, preset: &Preset) -> Res
             .map_err(|e| format!("lpoptions failed: {}", e))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            eprintln!("[PrintQueue] lpoptions stderr: {}", stderr.trim());
+            eprintln!("[HelloPrint] lpoptions stderr: {}", stderr.trim());
         }
     }
 
@@ -789,7 +789,7 @@ fn submit_print_unix(file_path: &Path, printer_id: &str, preset: &Preset) -> Res
     cmd.arg(&pdf_path);
 
     eprintln!(
-        "[PrintQueue] lp -d {} -n {} {}",
+        "[HelloPrint] lp -d {} -n {} {}",
         printer_id,
         preset.copies,
         pdf_path.display()
@@ -799,9 +799,9 @@ fn submit_print_unix(file_path: &Path, printer_id: &str, preset: &Preset) -> Res
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    eprintln!("[PrintQueue] lp stdout: {}", stdout.trim());
+    eprintln!("[HelloPrint] lp stdout: {}", stdout.trim());
     if !stderr.is_empty() {
-        eprintln!("[PrintQueue] lp stderr: {}", stderr.trim());
+        eprintln!("[HelloPrint] lp stderr: {}", stderr.trim());
     }
 
     // Clean up temp PDF
@@ -871,7 +871,7 @@ fn wrap_image_in_pdf(
     let offset_y = (height_pt - img_height) / 2.0;
 
     eprintln!(
-        "[PrintQueue] PDF: page={:.1}x{:.1} pt ({:.2}x{:.2} in) PageSize={}",
+        "[HelloPrint] PDF: page={:.1}x{:.1} pt ({:.2}x{:.2} in) PageSize={}",
         width_pt,
         height_pt,
         width_pt / 72.0,
@@ -879,7 +879,7 @@ fn wrap_image_in_pdf(
         page_size_key
     );
     if scaling_factor != 1.0 {
-        eprintln!("[PrintQueue] Scale compensation: factor={:.4}, image={:.1}x{:.1}, offset=({:.1},{:.1})",
+        eprintln!("[HelloPrint] Scale compensation: factor={:.4}, image={:.1}x{:.1}, offset=({:.1},{:.1})",
             scaling_factor, img_width, img_height, offset_x, offset_y);
     }
 
@@ -889,7 +889,7 @@ fn wrap_image_in_pdf(
     let (img_w, img_h) = ::image::GenericImageView::dimensions(&img);
 
     eprintln!(
-        "[PrintQueue] Image: {}x{} px, {} bytes",
+        "[HelloPrint] Image: {}x{} px, {} bytes",
         img_w,
         img_h,
         image_bytes.len()
@@ -902,7 +902,7 @@ fn wrap_image_in_pdf(
         .unwrap_or_default();
 
     let (stream_bytes, filter) = if ext == "jpg" || ext == "jpeg" {
-        eprintln!("[PrintQueue] JPEG passthrough: {} bytes", image_bytes.len());
+        eprintln!("[HelloPrint] JPEG passthrough: {} bytes", image_bytes.len());
         (image_bytes, "DCTDecode")
     } else {
         let rgb = img.to_rgb8();
@@ -918,7 +918,7 @@ fn wrap_image_in_pdf(
                 .map_err(|e| format!("Compression error: {}", e))?
         };
         eprintln!(
-            "[PrintQueue] FlateDecode: {} → {} bytes",
+            "[HelloPrint] FlateDecode: {} → {} bytes",
             raw_pixels.len(),
             compressed.len()
         );
@@ -981,7 +981,7 @@ fn wrap_image_in_pdf(
     doc.trailer.set("Root", catalog_id);
 
     let pdf_path = std::env::temp_dir().join(format!(
-        "printqueue_{}.pdf",
+        "helloprint_{}.pdf",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -992,7 +992,7 @@ fn wrap_image_in_pdf(
         .map_err(|e| format!("Failed to save PDF: {}", e))?;
 
     eprintln!(
-        "[PrintQueue] Generated PDF: {} ({:.1} KB)",
+        "[HelloPrint] Generated PDF: {} ({:.1} KB)",
         pdf_path.display(),
         fs::metadata(&pdf_path)
             .map(|m| m.len() as f64 / 1024.0)
@@ -1024,7 +1024,7 @@ pub fn get_cups_scaling_factor(printer_id: &str, page_size_key: &str) -> f32 {
     let content = match fs::read_to_string(&ppd_path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("[PrintQueue] Could not read PPD at {}: {}", ppd_path, e);
+            eprintln!("[HelloPrint] Could not read PPD at {}: {}", ppd_path, e);
             return 1.0;
         }
     };
@@ -1056,7 +1056,7 @@ pub fn get_cups_scaling_factor(printer_id: &str, page_size_key: &str) -> f32 {
                 .unwrap_or(after.len());
             if let Ok(factor) = after[..end].parse::<f32>() {
                 eprintln!(
-                    "[PrintQueue] PPD cupsBorderlessScalingFactor for {}: {}",
+                    "[HelloPrint] PPD cupsBorderlessScalingFactor for {}: {}",
                     page_size_key, factor
                 );
                 return factor;
@@ -1068,7 +1068,7 @@ pub fn get_cups_scaling_factor(printer_id: &str, page_size_key: &str) -> f32 {
     }
 
     eprintln!(
-        "[PrintQueue] No cupsBorderlessScalingFactor found for {} in PPD",
+        "[HelloPrint] No cupsBorderlessScalingFactor found for {} in PPD",
         page_size_key
     );
     1.0
@@ -1093,7 +1093,7 @@ pub fn get_cups_scaling_factor_by_keyword(printer_id: &str, keyword: &str) -> f3
     let content = match fs::read_to_string(&ppd_path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("[PrintQueue] Could not read PPD at {}: {}", ppd_path, e);
+            eprintln!("[HelloPrint] Could not read PPD at {}: {}", ppd_path, e);
             return 1.0;
         }
     };
@@ -1138,7 +1138,7 @@ pub fn get_cups_scaling_factor_by_keyword(printer_id: &str, keyword: &str) -> f3
                 .unwrap_or(after.len());
             if let Ok(factor) = after[..end].parse::<f32>() {
                 eprintln!(
-                    "[PrintQueue] PPD cupsBorderlessScalingFactor for keyword '{}': {}",
+                    "[HelloPrint] PPD cupsBorderlessScalingFactor for keyword '{}': {}",
                     keyword, factor
                 );
                 return factor;
@@ -1147,7 +1147,7 @@ pub fn get_cups_scaling_factor_by_keyword(printer_id: &str, keyword: &str) -> f3
     }
 
     eprintln!(
-        "[PrintQueue] No cupsBorderlessScalingFactor found for keyword '{}' in PPD",
+        "[HelloPrint] No cupsBorderlessScalingFactor found for keyword '{}' in PPD",
         keyword
     );
     1.0

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "print-queue",
+  "productName": "Hello Print",
   "version": "../package.json",
-  "identifier": "com.admin.print-queue",
+  "identifier": "studio.hellomagnets.hello-print",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "devUrl": "http://localhost:1420",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "PrintQueue",
+        "title": "Hello Print",
         "width": 900,
         "height": 650,
         "minWidth": 680,
@@ -39,7 +39,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEVBRjUyMkRCM0UwNzhGNDcKUldSSGp3YysyeUwxNnMycjJqTFRKZDZ5bEZzQzRsRWRBVDNjRldEdzlPYVg1Zm1UNmlKdWZGZkMK",
       "endpoints": [
-        "https://github.com/jakeklassen/print-queue/releases/latest/download/latest.json"
+        "https://github.com/jakeklassen/hello-print/releases/latest/download/latest.json"
       ]
     }
   }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,7 +1,7 @@
 {
   "bundle": {
     "resources": {
-      "macos-helper/printqueue-macos-helper": "macos-helper/printqueue-macos-helper"
+      "macos-helper/hello-print-macos-helper": "macos-helper/hello-print-macos-helper"
     }
   }
 }

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -15,7 +15,7 @@ const ThemeProviderContext = createContext<ThemeProviderState>({
 export function ThemeProvider({
   children,
   defaultTheme = "system",
-  storageKey = "printqueue-theme",
+  storageKey = "helloprint-theme",
 }: {
   children: React.ReactNode;
   defaultTheme?: Theme;

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -161,7 +161,7 @@ export function SettingsPage() {
         <CardHeader>
           <CardTitle className="text-base">Watch Folder</CardTitle>
           <CardDescription>
-            The folder PrintQueue monitors for new files.
+            The folder Hello Print monitors for new files.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
@@ -258,7 +258,7 @@ export function SettingsPage() {
         <CardHeader>
           <CardTitle className="text-base">About</CardTitle>
           <CardDescription>
-            PrintQueue v{appVersion}
+            Hello Print v{appVersion}
             {platform ? ` (${platform})` : ""} — Made by Jake Klassen of{" "}
             <a
               href="https://hellomagnets.studio"


### PR DESCRIPTION
Renames the tool to **Hello Print** (repo `hello-print`) per hello-magnets #665.

This is the do-now slice of **T1 (#18)** — the rename + metadata. The remaining T1 boxes (macOS notarization, Windows Authenticode signing, repo privatization) stay open. **Privatization remains gated on the authed update path (T3 #20)** landing first, so this PR keeps the repo public and only repoints the updater to the new public URL.

## Changes
- `productName` → `Hello Print`; bundle identifier `com.admin.print-queue` → `studio.hellomagnets.hello-print`
- Updater endpoint repointed to the new **public** `hello-print` repo URL (interim; T3 swaps to the platform authed endpoint)
- Rust crate `print-queue` → `hello-print`, lib `print_queue_lib` → `hello_print_lib`
- macOS helper binary/source → `hello-print-macos-helper` / `HelloPrintMacHelper.swift`
- Window title, tray, Settings/About text, log tags (`[HelloPrint]`), temp-file prefixes, theme storage key
- Signing key file → `.keys/hello-print.key` — **pubkey unchanged**, so updater signature continuity is preserved
- `Cargo.toml` boilerplate `authors`/`description` fixed
- Docs: README (artifact filenames now `Hello Print_…`), PRD, CLAUDE.md, current-state

## Deliberately preserved
- `.NET` `PrintQueue.AddJob()` / `GetPrintQueue()` API calls (not our app name)
- The **Print Queue** screen name — a view within Hello Print, not the app

## Gotchas (accepted, early-stage)
- Changing the identifier resets app-data/presets for existing installs
- Renamed `productName` may install alongside an old `print-queue` install rather than replacing it — a one-time manual reinstall for existing test installs

## Verification
- `pnpm check` ✅ (lint, stylelint, oxfmt, tsc + vite build)
- `cargo check` ✅ (crate builds as `hello-print`; only pre-existing dead-code warnings)

Part of #18 · epic jakeklassen/hello-magnets#665

🤖 Generated with [Claude Code](https://claude.com/claude-code)